### PR TITLE
Restrict robot to specific chat

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,0 +1,24 @@
+#-------------------------------------------------------------------------------------------------------------
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License. See https://go.microsoft.com/fwlink/?linkid=2090316 for license information.
+#-------------------------------------------------------------------------------------------------------------
+
+FROM mcr.microsoft.com/dotnet/core/sdk:2.2
+
+# Avoid warnings by switching to noninteractive
+ENV DEBIAN_FRONTEND=noninteractive
+
+# Configure apt and install packages
+RUN apt-get update \
+    && apt-get -y install --no-install-recommends apt-utils 2>&1 \
+    #
+    # Verify git, process tools, lsb-release (common in install instructions for CLIs) installed
+    && apt-get -y install git procps lsb-release \
+    #
+    # Clean up
+    && apt-get autoremove -y \
+    && apt-get clean -y \
+    && rm -rf /var/lib/apt/lists/*
+
+# Switch back to dialog for any ad-hoc use of apt-get
+ENV DEBIAN_FRONTEND=dialog

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,18 @@
+// See https://aka.ms/vscode-remote/devcontainer.json for format details.
+{
+	"name": "C# (.NET Core 2.2)",
+	"dockerFile": "Dockerfile",
+	
+	// Uncomment the next line if you want to publish any ports.
+	// "appPort": [],
+
+	// Uncomment the next line if you want to add in default container specific settings.json values
+	// "settings":  { "workbench.colorTheme": "Quiet Light" },
+
+	// Uncomment the next line to run commands after the container is created.
+	// "postCreateCommand": "dotnet restore"
+
+	"extensions": [
+		"ms-vscode.csharp"
+	]
+}

--- a/Config/BotConfig.cs
+++ b/Config/BotConfig.cs
@@ -12,5 +12,7 @@ namespace ImageSearchBot.Config
         public List<string> Responses { get; set; }
         
         public List<string> Keywords { get; set; }
+
+        public long? ChatId { get; set; }
     }
 }

--- a/ImgBot.cs
+++ b/ImgBot.cs
@@ -58,7 +58,15 @@ namespace ImageSearchBot
         {
             var message = e.Message;
 
-            var isPrivate = e.Message.Chat.Type == ChatType.Private;
+            // restrict the robot to a specific chat
+            if(_config.ChatId != null && message.Chat.Id != _config.ChatId.Value)
+            {
+                await _bot.SendTextMessageAsync(message.Chat.Id,
+                        "This chat is not authorized to use this robot");
+                return;
+            }
+
+            var isPrivate = message.Chat.Type == ChatType.Private;
 
             if (isPrivate || message.Text.Contains($"@{_me.Username}"))
             {
@@ -97,6 +105,9 @@ namespace ImageSearchBot
         {
             _bot.StartReceiving(Array.Empty<UpdateType>());
             Console.WriteLine($"@{_me.Username}: started");
+            
+            if(_config.ChatId != null)
+                Console.WriteLine($"@{_me.Username}: restricted to chat {_config.ChatId}");
         }
 
         public void Stop()

--- a/Program.cs
+++ b/Program.cs
@@ -61,7 +61,8 @@ namespace ImageSearchBot
             var cfg = JsonConvert.DeserializeObject<RootConfig>(contents, 
                 new JsonSerializerSettings()
                 {
-                    ContractResolver = new CamelCasePropertyNamesContractResolver() 
+                    ContractResolver = new CamelCasePropertyNamesContractResolver(),
+                    NullValueHandling = NullValueHandling.Ignore
                 });
 
             Assert.Check(cfg != null, "Root configuration must be set");


### PR DESCRIPTION
Adds a new nullable parameter inside "botConfig" that restrict the robot to a specific chat. Also adds null value handling for configuration, in order to prevent polluting the robot config files with null values.